### PR TITLE
Update use of AVR library <util/delay.h> so it can compile on ESP8266

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -35,7 +35,15 @@
 ******************************************************************************/
 
 #include "INA219.h"
-#include <util/delay.h>
+
+#if defined(ESP8266)
+  #define _delay_ms(ms) delayMicroseconds((ms) * 1000)
+#endif
+
+#ifdef __avr__
+  #include <util/delay.h>
+#endif
+
 namespace{
 // config. register bit labels
 const uint8_t RST =	15;


### PR DESCRIPTION
The original code won't compile on an ESP8266 platform. Whit the purposed change it will.