### PR TITLE
Replacing _delay_ms() by delay()

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -36,10 +36,6 @@
 
 #include "INA219.h"
 
-#if defined(ESP8266) || defined(ESP32)
-  #define _delay_ms(ms) delayMicroseconds((ms) * 1000)
-#endif
-
 #ifdef __avr__
   #include <util/delay.h>
 #endif
@@ -151,7 +147,7 @@ void INA219::configure(  t_range range,  t_gain gain,  t_adc  bus_adc,  t_adc sh
 #define INA_RESET        0xFFFF    // send to CONFIG_R to reset unit
 void INA219::reset(){
   write16(CONFIG_R, INA_RESET);
-  _delay_ms(5);
+  delay(5);
 }
 
 int16_t INA219::shuntVoltageRaw() const {


### PR DESCRIPTION
Hello,

I'm not sure why you use _delay_ms() only once and delay() is used in INA219::write16(). I would suggest to move everything delay(), so there is an easier support for arduino in general.

Thanks,