### PR TITLE
No need to call TwoWire::endTransmission() when reading values

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -300,7 +300,5 @@ int16_t INA219::read16(t_reg a) const {
     ret |= Wire.receive(); // rx lo byte
   #endif
 
-  Wire.endTransmission(); // end transmission
-
   return ret;
 }


### PR DESCRIPTION
TwoWire::endTransmission() should not be called.