### PR TITLE
Should not release i2c bus between the read request and the read itself

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -262,7 +262,7 @@ bool INA219::overflow() const {
 *             INTERNAL I2C FUNCTIONS                  *
 **********************************************************************/
 
-void INA219::write16(t_reg a, uint16_t d) const {
+void INA219::write16(t_reg a, uint16_t d, bool stop) const {
   uint8_t temp;
   temp = (uint8_t)d;
   d >>= 8;
@@ -278,7 +278,7 @@ void INA219::write16(t_reg a, uint16_t d) const {
     Wire.send(temp); // write data lobyte;
   #endif
 
-  Wire.endTransmission(); // end transmission
+  Wire.endTransmission(stop); // end transmission
   delay(1);
 }
 
@@ -286,7 +286,7 @@ int16_t INA219::read16(t_reg a) const {
   uint16_t ret;
 
   // move the pointer to reg. of interest, null argument
-  write16(a, 0);
+  write16(a, 0, false);
   
   Wire.requestFrom((int)i2c_address, 2);    // request 2 data bytes
 

--- a/INA219.h
+++ b/INA219.h
@@ -208,6 +208,7 @@ class INA219
     /// When selecting a register pointer to read from, (d) = 0
     void write16( t_reg addr,   ///< Register address.
     		      uint16_t data ///< Data to be writen.
+    		      bool stop = true // false if the i2c bus should not be released.
     		     ) const;
 
 };


### PR DESCRIPTION
This patch should be useful only when having 2 masters on the same bus.

The method TwoWire::requestFrom() does end the end transmission by default (unless the parameter "stop" is set to false).