### PR TITLE
Interpret bus voltage as uint16_t

### DIFF
--- a/INA219.cpp
+++ b/INA219.cpp
@@ -164,7 +164,7 @@ float INA219::shuntVoltage() const {
   return (temp / 100000);
 }
 
-int16_t INA219::busVoltageRaw() {
+uint16_t INA219::busVoltageRaw() {
   uint16_t bus_voltage_register = read16(V_BUS_R);
   _overflow = bitRead(bus_voltage_register, OVF_B);     // overflow bit
   _ready    = bitRead(bus_voltage_register, CNVR_B);    // ready bit
@@ -173,7 +173,7 @@ int16_t INA219::busVoltageRaw() {
 
 
 float INA219::busVoltage() {
-  int16_t temp;
+  uint16_t temp;
   temp = busVoltageRaw();
   temp >>= 3;
   return (temp * 0.004);

--- a/INA219.h
+++ b/INA219.h
@@ -154,7 +154,7 @@ class INA219
     int16_t shuntVoltageRaw() const;
 
     /// Returns raw bus voltage binary value.
-    int16_t busVoltageRaw();
+    uint16_t busVoltageRaw();
 
     /// Returns raw current binary value.    
     int16_t shuntCurrentRaw() const;


### PR DESCRIPTION
Without this patch values >2^15 will be interpreted as negative values.
Therefore the right shift in INA219::busVoltage() will do a sign
extension.
This issue was seen on ESP8266 when measuring voltages above 16V.

In the Arduino Adafruit_INA219 library uint16_t is used for the bus
voltage similar to this patch. See
https://github.com/adafruit/Adafruit_INA219/blob/2.1.0/Adafruit_INA219.cpp#L78